### PR TITLE
View and sort characters by Maxed Stats

### DIFF
--- a/lib/mule.js
+++ b/lib/mule.js
@@ -954,6 +954,14 @@
                 carr[i].muledump.TotalFame = fame;
 
                 //  add ?/8
+                carr[i].muledump.MaxedStats = 0;
+                for (var t = 0; t < STATTAGS.length; t++) {
+                    var s = carr[i][STATTAGS[t]] || 0;
+                    var cl = classes[carr[i].ObjectType];
+                    if(parseInt(s) === cl[3][t]){
+                        carr[i].muledump.MaxedStats++;
+                    }
+                }
 
             }
 
@@ -1062,6 +1070,10 @@
             }
 
             //  active time
+        } else if ( this.opt('chsort') === '6' ){
+            carr.sort(function(a,b) {
+                return a.muledump.MaxedStats < b.muledump.MaxedStats;
+            })
         } else if ( this.opt('chsort') === '5' ) {
 
             carr.sort(function(a,b) {
@@ -1154,14 +1166,13 @@
                 var portimg = $('<img class="portrait">');
                 window.portrait(portimg, c.Texture || c.ObjectType, c.Tex1, c.Tex2);
                 var chtext = $('<div>')
-                    .append($('<div style="padding-top: 3px;">').text(cl[0] + ' ' + c.Level + ', #' + c.id))
+                    .append($('<div style="padding-top: 3px;">').text(cl[0] + ' ' + c.Level + ", " + c.muledump.MaxedStats + "/8" + ', #' + c.id))
                     .append($('<div>').text(c.CurrentFame + ' F ' + c.Exp + ' XP'));
 
                 var chdesc = $('<div class="chdesc">')
                     .append(portimg)
                     .append(boost)
-                    .append(chtext);
-
+                    .append(chtext)
 
                 //  adjustments
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -59,7 +59,7 @@
         'chdesc': 'Char Description',
         'chsortchoice': {
             'label': 'Char Sort',
-            'radio': ['chsort', {0: 'ID', 1: 'Base Fame', 2: 'Total Fame', 3: 'Base Exp', 4: 'Class', 5: 'Active Time', 100: 'Custom'}]
+            'radio': ['chsort', {0: 'ID', 1: 'Base Fame', 2: 'Total Fame', 3: 'Base Exp', 4: 'Class', 5: 'Active Time', 6: 'Maxed Stats', 100: 'Custom'}]
         },
         'equipment': 'Equipment',
         'hpmp': 'HP/MP Pots',


### PR DESCRIPTION
- Allows the viewing of Maxed Stats next to Level in character description.
- Allows sorting by Maxed Stats. (chsort 6)

This should resolve issues [#94](https://github.com/jakcodex/muledump/issues/94) and [#95](https://github.com/jakcodex/muledump/issues/95).