### PR TITLE
Fix PNG artifacts making some skins black

### DIFF
--- a/lib/muledump/portrait.js
+++ b/lib/muledump/portrait.js
@@ -211,13 +211,15 @@
                 }
 
                 if (p_comp(mask, xi, yi, 3) > 1) {
-                    if (tex1) {
-                        vol = p_comp(mask, xi, yi, 0);
-                        if (vol > 1) dotex(fs1);
-                    }
-                    if (tex2) {
-                        vol = p_comp(mask, xi, yi, 1);
-                        if (vol > 1) dotex(fs2);
+                    var red = p_comp(mask, xi, yi, 0);
+                    var green = p_comp(mask, xi, yi, 1);
+
+                    if (red > green && tex1) {
+                        vol = red;
+                        dotex(fs1)
+                    } else if (green > red && tex2) {
+                        vol = green;
+                        dotex(fs2);
                     }
                 }
                 // outline


### PR DESCRIPTION
Fixed by always applying the strongest component in each pixels rather than all components > 1