### PR TITLE
Small Portrait Fixes

### DIFF
--- a/lib/muledump/mule.js
+++ b/lib/muledump/mule.js
@@ -1241,7 +1241,7 @@
                 }
 
                 var portimg = $('<img class="portrait">');
-                window.portrait(portimg, c.Texture || c.ObjectType, c.Tex1, c.Tex2);
+                window.portrait(portimg, c.ObjectType, c.Texture, c.Tex1, c.Tex2);
                 var chtext = $('<div>')
                     .append(boost)
                     .append($('<div style="padding-top: 3px;">').text(cl[0] + ' ' + c.Level + ", " + c.muledump.MaxedStats + "/8" + ', #' + c.id))

--- a/lib/muledump/portrait.js
+++ b/lib/muledump/portrait.js
@@ -128,7 +128,7 @@
         var spr = sprites[i][c];
         fsc = fsc || document.createElement('canvas');
         var ca = fsc;
-        var scale = ratio/5;
+        var scale = ratio / 5;
         ca.width = spr.width;
         ca.height = spr.height;
         var cact = ca.getContext('2d');
@@ -136,7 +136,7 @@
         cact.putImageData(spr, 0, 0);
         var p = cact.createPattern(ca, 'repeat');
         ca.width = scale * spr.width;
-        ca.height =  scale * spr.height;
+        ca.height = scale * spr.height;
         cact.scale(scale, scale);
         cact.fillStyle = p;
         cact.fillRect(0, 0, spr.width, spr.height);
@@ -165,8 +165,10 @@
         if ( !skinData ) return;
         var c = pcache[pCacheId(skin, tex1, tex2)];
 
+        var x16 = skinData[2];
+
         //  adjustments
-        if ( [11,13].indexOf(skinData[1]) > -1 ) img.css({
+        if ( x16 && [11,13].indexOf(skinData[1]) > -1 ) img.css({
             "overflow": 'hidden',
             "margin-top": '-7px',
             "margin-right": "7px"
@@ -174,7 +176,7 @@
 
         if (c) return img.attr('src', c);
 
-        var x16 = skinData[2];
+
         // size of the original sprite
         var size = x16 ? 16 : 8;
         // ratio at which the sprite is drawn (2: -> 8x8 -> 16x16)

--- a/lib/muledump/portrait.js
+++ b/lib/muledump/portrait.js
@@ -153,8 +153,14 @@
     var queue = [];
 
     var st;
-    window.portrait = function (img, skin, tex1, tex2) {
+    window.portrait = function (img, type, skin, tex1, tex2) {
         if (!ready) return queue.push(Array.prototype.slice.apply(arguments));
+
+        // fallback to default skin, this happens when loading new skins on outdated renders
+        if (!skin || !window.skins[skin]) {
+            skin = type
+        }
+
         var skinData = window.skins[skin];
         if ( !skinData ) return;
         var c = pcache[pCacheId(skin, tex1, tex2)];


### PR DESCRIPTION
- fallback to default skin when an invalid skin is loaded (outdated renders)
- don't apply beefcake adjustments to default trickster / ninja