### PR TITLE
Fallback to default skin when sprite is missing

### DIFF
--- a/lib/muledump/portrait.js
+++ b/lib/muledump/portrait.js
@@ -162,7 +162,14 @@
         }
 
         var skinData = window.skins[skin];
+
+        // try to fallback to default skin again if renders don't match constants
+        if ( !skinData || !sprites[skinData[3]][skinData[1]] ) {
+            skin = type;
+            skinData = window.skins[skin];
+        }
         if ( !skinData ) return;
+
         var c = pcache[pCacheId(skin, tex1, tex2)];
 
         var x16 = skinData[2];


### PR DESCRIPTION
This should only happen in the rare occasion where a local user has updated only `constants.js` and not `renders.png` / `sheets.js`.