### PR TITLE
Fix ancestor fame achievement

### DIFF
--- a/lib/muledump/pcstats.js
+++ b/lib/muledump/pcstats.js
@@ -70,8 +70,8 @@ var shortdungeonnames = { // sorted by "tier"
 };
 
 var bonuses = {
-    'Ancestor': function(s, c) {
-        return (c.id < 2) ? {mul: 0.1, add: 20} : 0;
+    'Ancestor': function(s, c, d) {
+        return (parseInt(d.Account.Stats.TotalFame) === 0) ? {mul: 0.1, add: 20} : 0;
     },
     'Legacy Builder': function(s, c, d) {
         // 0.1


### PR DESCRIPTION
Don't base the achievement on char id == 1, the correct check is the account having no fame gained so far.