### PR TITLE
Initial support for /account/verify API.

### DIFF
--- a/lib/muledump/mule.js
+++ b/lib/muledump/mule.js
@@ -562,7 +562,7 @@
         setuptools.app.uaTiming('mule', 'realmAPICharListGet', 'start', this.guid);
         $.ajax({
             dataType: "text",
-            url: realmApiURL + "/account/verify",
+            url: realmApiURL + "/account/verify?" + $.param(setuptools.config.realmApiParams),
             method: "POST",
             data: $.param(CR),
             success: function(xml, textStatus, request) {

--- a/lib/muledump/mule.js
+++ b/lib/muledump/mule.js
@@ -572,7 +572,7 @@
                 if (accessToken) {
                     window.realmAPI(
                         'char/list',
-                        { guid: this.guid, accessToken: accessToken[1] },
+                        { accessToken: accessToken[1] },
                         { url: realmApiURL },
                         function(xhr) {
                             xhr.done(onResponse).fail(onFail)

--- a/lib/muledump/mule.js
+++ b/lib/muledump/mule.js
@@ -536,7 +536,7 @@
 
         if ( cache_only === true ) return;
 
-        var CR = { guid: this.guid };
+        var CR = { guid: this.guid, clientToken: 0 };
         var pass = window.accounts[this.guid] || '';
 
         //  don't accept blank passwords
@@ -560,14 +560,36 @@
         ) realmApiURL = setuptools.config.appspotTesting;
 
         setuptools.app.uaTiming('mule', 'realmAPICharListGet', 'start', this.guid);
-        window.realmAPI(
-            'char/list',
-            CR,
-            {url: realmApiURL},
-            function(xhr) {
-                xhr.done(onResponse).fail(onFail)
-            }
-        );
+        $.ajax({
+            dataType: "text",
+            url: realmApiURL + "/account/verify",
+            method: "POST",
+            data: $.param(CR),
+            success: function(xml, textStatus, request) {
+                window.techlog("Response from api: " + xml, "api");
+
+                var accessToken = xml.match(/<AccessToken>(.+)<\/AccessToken>/);
+                if (accessToken) {
+                    window.realmAPI(
+                        'char/list',
+                        { guid: this.guid, accessToken: accessToken[1] },
+                        { url: realmApiURL },
+                        function(xhr) {
+                            xhr.done(onResponse).fail(onFail)
+                        }
+                    );
+                } else {
+                    self.queueFinish(self.guid, 'error', false, xml);
+                    self.error(xml);
+                    setuptools.app.ga('send', 'event', {
+                        eventCategory: 'detect',
+                        eventAction: 'accountVerifyError'
+                    });
+                }
+            },
+            error: onFail,
+            timeout: setuptools.config.realmApiTimeout
+        })
 
         function onFail(xhr) {
 


### PR DESCRIPTION
Some things that should happen before "full" support:

# New API responses
For example, `Account credentials not valid` is now `WebChangePasswordDialog.passwordError`.
Most error handling should be moved from the `/char/list` callback to the `/account/verify` callback.
Currently, no errors are specifically checked for. If the rate limiter kicks in at the wrong time, it won't backoff.
`acceptTOS`, `doMigration`, `verifyage` etc may need to be updated.

# Caching
`accessToken`s are invalidated after the time limit specified in the API response (currently, about 15 days).
They are also invalidated the next time `/account/verify` is called - for example, by another instance of muledump or by the exalt launcher.
If the cache is right, it takes 1 API call per account. If it's disabled, it takes 2 API calls per account. If it's wrong, it takes 3 API calls per account.
There should be an option to disable the cache, globally or per-account.

# Rate limiting
Anecdotally, I haven't had any problems with 50 accounts using "Automatic (Throttled)" and no cache.
Either that setting is 2+ times slower than the true rate limit, or the endpoints have separate rate limits.
EDIT: Got a report of hitting the 5 minute backoff with more than 60 accounts.

# OCL
The `/account/verify` call needs to have a correct `clientToken` to launch the client. This could be calculated by the OCL script during installation, and pasted by the user into muledump's OCL setup.
My rewritten OCL has this code to calculate it:
```autohotkey
	FileDelete, %A_Temp%\GetClientToken.ps1
	FileAppend,
(
$stringAsStream = [System.IO.MemoryStream]`:`:new()
$writer = [System.IO.StreamWriter]`:`:new($stringAsStream)
$writer.write("$(Get-CimInstance -ClassName Win32_BaseBoard | foreach {$_.SerialNumber})$(Get-CimInstance -ClassName Win32_BIOS | foreach {$_.SerialNumber})$(Get-CimInstance -ClassName Win32_OperatingSystem | foreach {$_.SerialNumber})")
$writer.Flush()
$stringAsStream.Position = 0
echo "$(Get-FileHash -InputStream $stringAsStream -Algorithm SHA1 | foreach {$_.Hash})".ToLower() > %A_Temp%\GetClientToken.txt
), %A_Temp%\GetClientToken.ps1
	RunWait, PowerShell.exe -ExecutionPolicy Bypass -Command %A_Temp%\GetClientToken.ps1,, Hide
	FileRead, clientToken, %A_Temp%\GetClientToken.txt
```
I also made a Unity "game" that copies `SystemInfo.deviceUniqueIdentifier` in case the above fails, but haven't tried to integrate it with OCL.
(reference: https://stackoverflow.com/questions/55809274/how-do-i-get-same-hardware-id-as-in-unityengine-systeminfo-deviceuniqueidentifie/66187334#66187334)
There's another endpoint to hit: `POST /account/verifyAccessTokenClient` takes `clientToken` and `accessToken`.

# Other
Deca might appreciate it if we pass `muleDump=true` to `/account/verify` the same way we do to `/char/list`.

I'm not too sure what the `realmAPI` function does over `$.ajax`. We may want to update `realmAPI` to handle `POST` requests if the things it does are important for `/account/verify`

~~`muledump-cors-adapter-firefox` does not work with this endpoint for some reason. I haven't tried Chrome. I'm using this extension in the meantime: https://addons.mozilla.org/en-US/firefox/addon/cors-everywhere/~~ (making the adapter work is one of the things `realmAPI` does over `$.ajax` >_>)